### PR TITLE
Define default subcommand.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,11 +4,11 @@
 import PackageDescription
 
 let package = Package(
-    name: "tuist-plugin-swiftlint",
+    name: "tuist-plugin-lint",
     platforms: [.macOS(.v11)],
     products: [
         .executable(
-            name: "tuist-swiftlint",
+            name: "tuist-lint",
             targets: ["TuistPluginSwiftLint"]
         )
     ],

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ In order to tell Tuist you'd like to use SwiftLint plugin in your project follow
 The plugin provides a command for linting the Swift code of your projects by leveraging [SwiftLint](https://github.com/realm/SwiftLint). All you need to do is run the following command:
 
 ```
-tuist swiftlint
+tuist lint
 ```
 
 You can lint selected target by specifing its name:
 
 ```
-tuist swiftlint MyTarget
+tuist lint MyTarget
 ```
 
 ### Arguments
@@ -29,15 +29,15 @@ tuist swiftlint MyTarget
 For additional help you can call:
 
 ```
-tuist swiftlint --help
+tuist lint --help
 ```
 
 ### Subcommands
 
 | Subcommand  | Description  |
 |:-|:-|
-| `tuist swiftlint version-swiftlint`  | Outputs the current version of SwiftLint.  |
-| `tuist swiftlint version`  | Outputs the current version of the plugin.  |
+| `tuist lint version-swiftlint`  | Outputs the current version of SwiftLint.  |
+| `tuist lint version`  | Outputs the current version of the plugin.  |
 
 ## Contribute
 

--- a/Sources/TuistPluginSwiftLint/Commands/MainCommand.swift
+++ b/Sources/TuistPluginSwiftLint/Commands/MainCommand.swift
@@ -3,13 +3,13 @@ import ArgumentParser
 /// The entry point of the plugin. Main command that must be invoked in `main.swift` file.
 struct MainCommand: ParsableCommand {
     static var configuration = CommandConfiguration(
-        commandName: "plugin-swiftlint",
+        commandName: "plugin-lint",
         abstract: "A plugin that extends Tuist with linting code using SwiftLint.",
         subcommands: [
-            LintCommand.self, // lints code
+            SwiftLintCommand.self, // lints code
             VersionCommand.self, // prints version of the plugin
             VersionSwiftLintCommand.self, // prints version of SwiftLint
         ],
-        defaultSubcommand: LintCommand.self
+        defaultSubcommand: SwiftLintCommand.self
     )
 }

--- a/Sources/TuistPluginSwiftLint/Commands/MainCommand.swift
+++ b/Sources/TuistPluginSwiftLint/Commands/MainCommand.swift
@@ -9,6 +9,7 @@ struct MainCommand: ParsableCommand {
             LintCommand.self, // lints code
             VersionCommand.self, // prints version of the plugin
             VersionSwiftLintCommand.self, // prints version of SwiftLint
-        ]
+        ],
+        defaultSubcommand: LintCommand.self
     )
 }

--- a/Sources/TuistPluginSwiftLint/Commands/Subcommands/SwiftLintCommand.swift
+++ b/Sources/TuistPluginSwiftLint/Commands/Subcommands/SwiftLintCommand.swift
@@ -3,9 +3,9 @@ import TuistPluginSwiftLintFramework
 
 extension MainCommand {
     /// A command to lint the code using SwiftLint.
-    struct LintCommand: ParsableCommand {
+    struct SwiftLintCommand: ParsableCommand {
         static var configuration = CommandConfiguration(
-            commandName: "lint",
+            commandName: "swiftlint",
             abstract: "Lints the code of your projects using SwiftLint."
         )
         
@@ -22,7 +22,7 @@ extension MainCommand {
         var target: String?
         
         func run() throws {
-            try LintService()
+            try SwiftLintService()
                 .run(
                     path: path,
                     targetName: target

--- a/Sources/TuistPluginSwiftLintFramework/Services/SwiftLintService.swift
+++ b/Sources/TuistPluginSwiftLintFramework/Services/SwiftLintService.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ProjectAutomation
 
-enum LintServiceError: Error, CustomStringConvertible, Equatable {
+enum SwiftLintServiceError: Error, CustomStringConvertible, Equatable {
     /// Thrown when a graph can not be found at the given path.
     case graphNotFound
     
@@ -20,7 +20,7 @@ enum LintServiceError: Error, CustomStringConvertible, Equatable {
 }
 
 /// A service that manages code linting.
-public final class LintService {
+public final class SwiftLintService {
     private let swiftLintAdapter: SwiftLintFrameworkAdapting
     
     public init(
@@ -54,7 +54,7 @@ public final class LintService {
         do {
             return try Tuist.graph(at: path)
         } catch {
-            throw LintServiceError.graphNotFound
+            throw SwiftLintServiceError.graphNotFound
         }
     }
     
@@ -62,7 +62,7 @@ public final class LintService {
     private func getSourcesToLint(in graph: Graph, targetName: String?) throws -> [String] {
         if let targetName = targetName {
             guard let target = graph.allTargets.first(where: { $0.name == targetName }) else {
-                throw LintServiceError.targetNotFound(targetName: targetName)
+                throw SwiftLintServiceError.targetNotFound(targetName: targetName)
             }
             
             return target.sources


### PR DESCRIPTION
It allows to omit the `lint` subcommand in a call and makes linting more convenient.

**Before:** 

`tuist swiftlint lint`

**After:**

`tuist swiftlint`