### PR TITLE
Latest SwiftLint version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -29,6 +29,15 @@
         }
       },
       {
+        "package": "SwiftSyntax",
+        "repositoryURL": "https://github.com/apple/swift-syntax.git",
+        "state": {
+          "branch": null,
+          "revision": "0b6c22b97f8e9320bca62e82cdbee601cf37ad3f",
+          "version": "0.50600.1"
+        }
+      },
+      {
         "package": "swift-system",
         "repositoryURL": "https://github.com/apple/swift-system.git",
         "state": {
@@ -50,9 +59,9 @@
         "package": "SwiftLint",
         "repositoryURL": "https://github.com/realm/SwiftLint",
         "state": {
-          "branch": null,
-          "revision": "e8ef21fef61f12536964c4e3cf6d5a6e3ad81e49",
-          "version": "0.46.5"
+          "branch": "e497f1f",
+          "revision": "e497f1f5b161af96ba439049d21970c6204d06c6",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/tuist/ProjectAutomation", .exact("3.2.0")),
-        .package(url: "https://github.com/realm/SwiftLint", .exact("0.46.5")), // it is a core dependency of the plugin, the version should be under control and locked
+        .package(url: "https://github.com/realm/SwiftLint", revision: "e497f1f"), // v0.47.1, commit SHA due to its use of unsafe flags
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.0.0")),
     ],
     targets: [


### PR DESCRIPTION
* Update to latest SwiftLint version, 0.47.1.
* SwiftLint 0.47 uses unsafe flags and so you need to link against it using branch or commit SHA instead of version. Added a comment to explain that the commit SHA used matches 0.47.1.

SwiftLint 0.47.1 uses SwiftSyntax, which has caused quite an increase in its size and also was the cause of the unsafe flags, that then require the plugin to target commit SHA of the tag rather than the tag itself.

SwiftLint 0.46.5 was a 7.2MB ZIP, 28.9MB unzipped.
SwiftLint 0.47.1 is a 21.6MB ZIP, 60.9MB unzipped.

Tuist plugin with 0.46.5 was a 8.6MB ZIP, 34.9MB unzipped.
Tuist plugin with 0.47.1 is a 33.6MB ZIP, 124.8MB unzipped.

I noticed that when I used 'tuist plugin archive' the ZIP was same size as the binary (120ish MB), so I unzipped it and then re-zipped it manually to get a Tuist plugin ZIP of 33.6MB.