### PR TITLE
Fix reporting of lint issues at the end like SwiftLint CLI does

### DIFF
--- a/Sources/TuistPluginSwiftLintFramework/SwiftLintFrameworkAdapter/SwiftLintFramework+Extensions/StyleViolation+TuistPlugin.swift
+++ b/Sources/TuistPluginSwiftLintFramework/SwiftLintFrameworkAdapter/SwiftLintFramework+Extensions/StyleViolation+TuistPlugin.swift
@@ -66,13 +66,21 @@ extension Array where Element == StyleViolation {
         """
     }
     
-    /// Generates and prints report from violations using the given reporter.
-    func report(with reporter: Reporter.Type, realtimeCondition: Bool) {
-        if reporter.isRealtime == realtimeCondition {
+    /// Generates and prints report from violations using the given reporter, if the reporter is for realtime output.
+    func reportRealtime(with reporter: Reporter.Type) {
+        if reporter.isRealtime {
             let report = reporter.generateReport(self)
             if !report.isEmpty {
                 queuedPrint(report)
             }
+        }
+    }
+
+    /// Generates and prints report from violations using the given reporter, for realtime or batch output.
+    func report(with reporter: Reporter.Type) {
+        let report = reporter.generateReport(self)
+        if !report.isEmpty {
+            queuedPrint(report)
         }
     }
 }

--- a/Sources/TuistPluginSwiftLintFramework/SwiftLintFrameworkAdapter/SwiftLintFrameworkAdapter.swift
+++ b/Sources/TuistPluginSwiftLintFramework/SwiftLintFrameworkAdapter/SwiftLintFrameworkAdapter.swift
@@ -45,7 +45,7 @@ public final class SwiftLintFrameworkAdapter: SwiftLintFrameworkAdapting {
                     }
                     
                     linter.file.invalidateCache()
-                    currentViolations.report(with: reporter, realtimeCondition: true)
+                    currentViolations.reportRealtime(with: reporter)
                 }
             )
             
@@ -54,10 +54,10 @@ public final class SwiftLintFrameworkAdapter: SwiftLintFrameworkAdapting {
                 let thresholdViolation = StyleViolation.createThresholdViolation(threshold: warningThreshold)
                 
                 violations.append(thresholdViolation)
-                [thresholdViolation].report(with: reporter, realtimeCondition: true)
+                [thresholdViolation].reportRealtime(with: reporter)
             }
             
-            violations.report(with: reporter, realtimeCondition: false)
+            violations.report(with: reporter)
             let numberOfSeriousViolations = violations.numberOfViolations(severity: .error)
             if !quiet {
                 queuedPrintError(


### PR DESCRIPTION
* When you run SwiftLint CLI it reports errors/warnings when they are found, within the list of 'Lint FileName.swift' messages. Then, at the end it prints the list of collected violations.
* The Tuist plugin was collecting and trying to report these at the end, however, the report function had a realtime boolean parameter that when false, meant the report function did nothing.
* This has been split into 2 functions, one that only reports when realtime and the other that always reports that can be used at the end.